### PR TITLE
Adiciona lembrete para atualizar os extends dos pacotes

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -1,2 +1,9 @@
 [versions]
 # Itens aqui serao removidos quando de um novo release do Portal Padrao
+# Lembrar de atualizar os extends de:
+
+# https://github.com/plonegovbr/brasil.gov.portal/blob/master/buildout.cfg
+# https://github.com/plonegovbr/brasil.gov.temas/blob/master/buildout.cfg
+# https://github.com/plonegovbr/brasil.gov.paginadestaque/blob/master/buildout.cfg
+
+# quando um novo release for lançado em portalpadrao.release.


### PR DESCRIPTION
Quando um novo release for lançado, os extends de brasil.gov.portal,
brasil.gov.temas e brasil.gov.paginadestaque precisam ser atualizados.
Já ocorreram vezes em que o release foi lançado e os extends não foram
atualizados. Ver:
https://github.com/plonegovbr/brasil.gov.portal/issues/176
https://github.com/plonegovbr/brasil.gov.portal/pull/227#issuecomment-142418575