### PR TITLE
Removendo extensão 'buildout-versions'

### DIFF
--- a/buildout.d/base.cfg
+++ b/buildout.d/base.cfg
@@ -1,5 +1,4 @@
 [buildout]
-extensions = buildout-versions
 
 extends =
     http://downloads.plone.org.br/release/1.1.3/versions.cfg


### PR DESCRIPTION
Extensão foi incorporada ao buildout e não precisa mais ser incluída