### PR TITLE
Remove pinagem flake8-coding.

### DIFF
--- a/travis.cfg
+++ b/travis.cfg
@@ -39,6 +39,3 @@ eggs =
 # "AttributeError: 'PersistentCoverTileDataManager' object has no attribute 'annotations'"
 # Adicionado no plone.tiles 1.7.
 plone.tiles = 1.5.2
-
-# https://github.com/tk0miya/flake8-coding/issues/10
-flake8-coding = 1.2.2


### PR DESCRIPTION
Apesar dos builds quebrarem em

    https://travis-ci.org/plonegovbr/portal.buildout/jobs/165871565

e

    https://travis-ci.org/plonegovbr/portal.buildout/jobs/165871565

Esses é o mesmo erro que já ocorria antes em https://github.com/plonegovbr/portal.buildout/pull/53#issuecomment-245919241 e será corrigido quando o release 1.1.5 for gerado e alterado no base.cfg.