### PR TITLE
Despina plone.tiles 1.5.2.

### DIFF
--- a/travis.cfg
+++ b/travis.cfg
@@ -31,11 +31,3 @@ defaults = ['--auto-color', '--auto-progress']
 eggs =
     ${buildout:package-name} ${buildout:package-extras}
     ${buildout:test-eggs}
-
-[versions]
-# Além de manter a compatibilidade com os requisitos do cover
-# (https://github.com/collective/collective.cover/commit/f6a9127305068846231b6a76d3b08abcd2aeefdc)
-# evita o erro
-# "AttributeError: 'PersistentCoverTileDataManager' object has no attribute 'annotations'"
-# Adicionado no plone.tiles 1.7.
-plone.tiles = 1.5.2


### PR DESCRIPTION
O commit

https://github.com/plone/plone.tiles/commit/64887368193eec5c8ac951a746899a6334e509b8

Resolveu o problema de incompatibilidade que existia.