### PR TITLE
Despina selenium 2.48.0.

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -184,5 +184,4 @@ robotframework-selenium2library = 1.7.4
 robotframework-selenium2screenshots = 0.6.0
 robotframework-wavelibrary = 0.1.3
 robotsuite = 1.7.0
-selenium = 2.48.0
 sphinxcontrib-robotframework = 0.5.1


### PR DESCRIPTION
Passa a utilizar a versão que o próprio Plone usa. Plone 4.3.9 (que é hoje utilizado pelo IDG) usa o selenium 2.45.0, mas os releases posteriores ao 4.3.9 (como o http://dist.plone.org/release/4.3.14/versions.cfg) utilizam versões atuais e iremos por esse caminho.

Colocando essa versão ao invés da 2.48.0, em alguns firefoxes também evita o erro

assert last_status == 'PASS', last_message                                 
AssertionError: Setup failed:                                                 
WebDriverException: Message: Can't load the profile. Profile Dir: %s If you specified a log_file in the FirefoxBinary constructor, check it for details.

que também deixam de ocorrer nas versões mais atuais como a 2.53.5 (Pinada no Plone 4.3.14).