### PR TITLE
Despina zc.recipe.cmmi.

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -159,10 +159,6 @@ z3c.jbot = 0.7.2
 z3c.pt = 3.0.0a1
 z3c.recipe.usercrontab = 1.2.1
 z3c.unconfigure = 1.1
-# Release 2.0.0 pede zc.buildout >= 2.9.4. Quando o buildout
-# for atualizado ou se os cfgs de versões mais novas do Plone
-# pinarem esse pacote, poderá ser removido.
-zc.recipe.cmmi = 1.3.6
 zope.app.locales = 3.7.4
 zope.configuration = 3.8.1
 


### PR DESCRIPTION
Depois de 

https://github.com/collective/buildout.plonetest/pull/26/commits/14dc84e2dd07307ef49b2398a8b263621862eb69

A pinagem não se torna mais necessária. Isso ocorre porque a necessidade principal dessa pinagem era pra que todos os builds plonegovbr não quebrassem, pois todos herdam desse arquivo, mas todos também herdam de buildout.plonetest e, como em produção não temos necessidade de gc.recipe.node (que é quem pede zc.recipe.cmmi), essa pinagem não se torna mais necessária.