### PR TITLE
brasil.gov.paginadestaque = 1.1

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -41,7 +41,7 @@ argh = 0.23.3
 brasil.gov.agenda = 1.1
 brasil.gov.barra = 1.2
 brasil.gov.facetada = 1.0b1
-brasil.gov.paginadestaque = 1.0rc1
+brasil.gov.paginadestaque = 1.1
 # Se essa versão não for exatamente igual ao diretório de onde você obteve
 # em portalpadrao.release, isso não necessariamente é um erro: pode haver
 # pequenas variações de **bugfixes** pois um release envolve muitas


### PR DESCRIPTION
O erro na build parece ser um *mandelbug* pois ao reiniciar a build volta a funcionar. Devemos tratar isso em releases futuros. Foi aberto um relato em https://github.com/plonegovbr/brasil.gov.portal/issues/370 para se analisar essa questão.