### PR TITLE
Upgrade sc.microsite to 1.1b1

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -189,7 +189,7 @@ plone.api = 1.6
 # FIM collective.cover 4.3.x
 
 # usados pelo sc.microsite
-collective.behavior.localdiazo = 1.0b3
+collective.behavior.localdiazo = 1.1b1
 collective.behavior.localregistry = 1.0b2
 
 # Customizações na parte de testes.

--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -55,8 +55,6 @@ brasil.gov.tiles = 1.4rc1
 brasil.gov.vcge = 1.1
 buildout-versions = 1.7
 Chameleon = 2.22
-collective.behavior.localdiazo = 1.0b3
-collective.behavior.localregistry = 1.0b2
 collective.cover = 1.6b2
 # Usado pelo collective.cover.
 collective.js.galleria = 1.2.5
@@ -156,7 +154,7 @@ sc.contentrules.groupbydate = 2.0.1
 sc.contentrules.layout = 1.0.1
 sc.contentrules.metadata = 1.0.1
 sc.embedder = 1.5b2
-sc.microsite = 1.0b4
+sc.microsite = 1.1b1
 sc.social.like = 2.4.1
 sourcecodegen = 0.6.14
 SPARQLWrapper = 1.5.2
@@ -189,6 +187,10 @@ plone.namedfile = 3.0.11
 # XXX: https://github.com/plone/plone.api/issues/364
 plone.api = 1.6
 # FIM collective.cover 4.3.x
+
+# usados pelo sc.microsite
+collective.behavior.localdiazo = 1.0b3
+collective.behavior.localregistry = 1.0b2
 
 # Customizações na parte de testes.
 # Ao atualizar para Plone > 4.3.9, com exceção de robotframework-wavelibrary


### PR DESCRIPTION
This removes a direct dependency on five.grok.

WIP

we still need to wait for https://github.com/collective/collective.behavior.localdiazo/pull/12 and a new release of that package.