### PR TITLE
zc.buildout = 2.9.5

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -166,6 +166,11 @@ z3c.jbot = 0.7.2
 z3c.pt = 3.0.0a1
 z3c.recipe.usercrontab = 1.2.1
 z3c.unconfigure = 1.1
+# Todas as versões anteriores a essa dão erro no pypi, pois o buildout tenta pegar
+# por padrão uma url http do pypi mas agora só é aceito https. Favor ver
+# https://community.plone.org/t/disabling-non-https-access-to-apis-on-pypi/5069/12
+# para mais detalhes.
+zc.buildout = 2.9.5
 zope.app.locales = 3.7.4
 zope.configuration = 3.8.1
 


### PR DESCRIPTION
Todas as versões anteriores a essa dão erro no pypi, pois o buildout tenta pegar 
por padrão uma url http do pypi mas agora só é aceito https. Favor ver
https://community.plone.org/t/disabling-non-https-access-to-apis-on-pypi/5069/12
para mais detalhes.
zc.buildout = 2.9.5