### PR TITLE
Docker para portal 1.4

### DIFF
--- a/docker/1.4/Dockerfile
+++ b/docker/1.4/Dockerfile
@@ -1,0 +1,27 @@
+FROM plone/plone:4.3.15
+
+LABEL Name="Identidade Digital para o Governo Brasileiro Federal para Plone" \
+      maintainer="Carlos Vieira <edu.carlos.vieira@gmail.com>" \
+      Version="1.4" \
+      Architecture="x86_64" \
+      Dockerfile_location="/root/buildinfo"
+
+USER plone
+COPY site.cfg /plone/instance/
+
+USER root
+COPY Dockerfile /root/buildinfo
+
+# Para Pillow
+RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libyaml-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps \
+ && sudo -u plone bin/buildout -c site.cfg -t 300 \
+ && SUDO_FORCE_REMOVE=yes apt-get purge -y --auto-remove $buildDeps \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /plone/buildout-cache/downloads/* \
+ && apt-get clean \
+ && find /plone \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' +
+
+USER plone
+

--- a/docker/1.4/site.cfg
+++ b/docker/1.4/site.cfg
@@ -1,0 +1,21 @@
+[buildout]
+index = https://pypi.python.org/simple/
+extends =
+    buildout.cfg
+    http://downloads.plone.org.br/release/1.4/versions.cfg
+
+parts += zeoserver
+
+
+[instance]
+eggs += brasil.gov.portal
+
+[zeoserver]
+recipe = plone.recipe.zeoserver
+zeo-address = zeoserver:8100
+file-storage = /data/filestorage/Data.fs
+blob-storage = /data/blobstorage
+
+[versions]
+
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "2"
+services:
+  haproxy:
+    image: eeacms/haproxy
+    ports:
+    - 80:5000
+    - 1936:1936
+    depends_on:
+    - plone
+    environment:
+      BACKENDS: "plone"
+      BACKENDS_PORT: "8080"
+      DNS_ENABLED: "True"
+
+  plone:
+    image: plonegovbr/plonegovbr
+    depends_on:
+    - zeoserver
+    environment:
+    - ZEO_ADDRESS=zeoserver:8100
+
+  zeoserver:
+    image: plone
+    command: zeoserver
+    volumes:
+    - data:/data
+
+volumes:
+  data:

--- a/docs/desenvolvimento.rst
+++ b/docs/desenvolvimento.rst
@@ -120,6 +120,53 @@ dos já existentes:
         mkdir-chameleon
         zopepy
 
+Instalação com Docker
+-----------------------
+
+Para instalação use o docker-compose ou crie com docker como o `manual <https://docs.plone.org/manage/docker/docs/index.html>`_.
+
+
+Um exemplo de **docker-compose.yml**.  
+
+::
+
+    version: "2"
+    services:
+      haproxy:
+    	 image: eeacms/haproxy
+    	 ports:
+    	 - 80:5000
+    	 - 1936:1936
+    	 depends_on:
+    	 - plone
+    	 environment:
+    	   BACKENDS: "plone"
+    	   BACKENDS_PORT: "8080"
+    	   DNS_ENABLED: "True"
+
+      plone:
+    	 image: plonegovbr/plonegovbr
+    	 depends_on:
+    	 - zeoserver
+    	 environment:
+    	 - ZEO_ADDRESS=zeoserver:8100
+
+      zeoserver:
+    	 image: plonegovbr/plonegovbr
+    	 command: zeoserver
+    	 volumes:
+    	 - data:/data
+
+    volumes:
+      data:
+
+Com o comando 
+.. code-block:: shell
+ 
+    docker-compose up -d
+
+Irá criar um serviço de haproxy que ira balancear os backends e um zeoserver. 
+
 Inicialização e controle
 ==========================
 


### PR DESCRIPTION
Adiciona uma imagem docker para o portal versão 1.4

Para testar:

```command
cd docker
docker build 1.4/ -t plonegovbr/plonegovbr
docker-compose up -d
```
Verificar o localhost e criar um novo Portal

Se esse PR for aceito teriamos que criar uma imagem no hub.docker.com com as tags dentro do plonegovbr/plonegovbr

closes https://github.com/plonegovbr/brasil.gov.portal/issues/246