### PR TITLE
Skip tests from brasil.gov.barra until new notice

### DIFF
--- a/travis-development.cfg
+++ b/travis-development.cfg
@@ -12,7 +12,7 @@ recipe = zc.recipe.testrunner
 defaults = ['--auto-color', '--auto-progress']
 eggs =
     brasil.gov.agenda [test]
-    brasil.gov.barra [test]
+#    brasil.gov.barra [test]
     brasil.gov.portal [test]
     brasil.gov.portlets [test]
     brasil.gov.temas [test]

--- a/travis-production.cfg
+++ b/travis-production.cfg
@@ -34,7 +34,7 @@ recipe = zc.recipe.testrunner
 defaults = ['--auto-color', '--auto-progress']
 eggs =
     brasil.gov.agenda [test]
-    brasil.gov.barra [test]
+#    brasil.gov.barra [test]
     brasil.gov.portal [test]
     brasil.gov.portlets [test]
     brasil.gov.temas [test]


### PR DESCRIPTION
There is a new version of the bar, but there is no clear date to implement it.

refs. https://github.com/plonegovbr/brasil.gov.barra/issues/49