### PR TITLE
 Corrige "Can't open /etc/init.d/xvfb" no travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ products/
 src/
 var/
 .python-version
+/.settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+services:
+  - xvfb
 language: python
 python: 2.7
 sudo: false
@@ -36,9 +38,6 @@ install:
 # arquivo onde procura a string, trocando bin/instance por parts/instance.site.py
 # por exemplo.
 - grep -q 'brasil.gov.portal' bin/instance
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 script:
 # FIXME: we have isolation issues running tests
 - bin/test -s brasil.gov.agenda &&


### PR DESCRIPTION
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Com isso, o formato de execução do xvfb foi alterado:

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

services:
  \- xvfb