### PR TITLE
Remove pinagem desnecessária de sc.recipe.staticresources

### DIFF
--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -107,7 +107,6 @@ sc.contentrules.layout = 1.0.1
 sc.contentrules.metadata = 1.0.1
 sc.embedder = 1.5b2
 sc.microsite = 1.1b1
-sc.recipe.staticresources = 1.1b5
 sc.social.like = 2.13b3
 sourcecodegen = 0.6.14
 SPARQLWrapper = 1.5.2

--- a/etc/versions.cfg
+++ b/etc/versions.cfg
@@ -340,7 +340,6 @@ sc.contentrules.layout = 1.0.1
 sc.contentrules.metadata = 1.0.1
 sc.embedder = 1.5b2
 sc.microsite = 1.1b1
-sc.recipe.staticresources = 1.1b5
 sc.social.like = 2.13b3
 select-backport = 0.2
 selenium = 2.53.6


### PR DESCRIPTION
Esse pacote é baixado pelo webpack e não pelo buildout.